### PR TITLE
Add new rewards role to AaveIncentivesController

### DIFF
--- a/contracts/stake/AaveDistributionManager.sol
+++ b/contracts/stake/AaveDistributionManager.sol
@@ -21,7 +21,7 @@ contract AaveDistributionManager is IAaveDistributionManager {
     mapping(address => uint256) users;
   }
 
-  uint256 public immutable DISTRIBUTION_END;
+  uint256 internal immutable _oldDistributionEnd;
 
   address public immutable EMISSION_MANAGER;
 
@@ -34,7 +34,7 @@ contract AaveDistributionManager is IAaveDistributionManager {
   event UserIndexUpdated(address indexed user, address indexed asset, uint256 index);
 
   constructor(address emissionManager, uint256 distributionDuration) public {
-    DISTRIBUTION_END = block.timestamp.add(distributionDuration);
+    _oldDistributionEnd = block.timestamp.add(distributionDuration);
     EMISSION_MANAGER = emissionManager;
   }
 
@@ -249,6 +249,14 @@ contract AaveDistributionManager is IAaveDistributionManager {
    * @return uint256 unix timestamp
    **/
   function _getDistributionEnd() internal view virtual returns (uint256) {
-    return DISTRIBUTION_END;
+    return _oldDistributionEnd;
+  }
+
+  /**
+   * @dev Keeps interface compatibility. Returns the timestamp of the end of the current distribution
+   * @return uint256 unix timestamp
+   **/
+  function DISTRIBUTION_END() external view returns (uint256) {
+    return _getDistributionEnd();
   }
 }

--- a/contracts/stake/AaveDistributionManager.sol
+++ b/contracts/stake/AaveDistributionManager.sol
@@ -219,13 +219,13 @@ contract AaveDistributionManager is IAaveDistributionManager {
       emissionPerSecond == 0 ||
       totalBalance == 0 ||
       lastUpdateTimestamp == block.timestamp ||
-      lastUpdateTimestamp >= DISTRIBUTION_END
+      lastUpdateTimestamp >= _getDistributionEnd()
     ) {
       return currentIndex;
     }
 
     uint256 currentTimestamp =
-      block.timestamp > DISTRIBUTION_END ? DISTRIBUTION_END : block.timestamp;
+      block.timestamp > _getDistributionEnd() ? _getDistributionEnd() : block.timestamp;
     uint256 timeDelta = currentTimestamp.sub(lastUpdateTimestamp);
     return
       emissionPerSecond.mul(timeDelta).mul(10**uint256(PRECISION)).div(totalBalance).add(
@@ -241,5 +241,14 @@ contract AaveDistributionManager is IAaveDistributionManager {
    **/
   function getUserAssetData(address user, address asset) public view returns (uint256) {
     return assets[asset].users[user];
+  }
+
+  /**
+   * @dev Returns the timestamp of the end of the current distribution
+   * @notice This field remains virtual to extend at AaveDistributionManageV2, keeping V1 logic
+   * @return uint256 unix timestamp
+   **/
+  function _getDistributionEnd() internal view virtual returns (uint256) {
+    return DISTRIBUTION_END;
   }
 }

--- a/contracts/stake/AaveDistributionManagerV2.sol
+++ b/contracts/stake/AaveDistributionManagerV2.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.5;
+pragma experimental ABIEncoderV2;
+
+import {SafeMath} from '../lib/SafeMath.sol';
+import {AaveDistributionManager} from './AaveDistributionManager.sol';
+
+/**
+ * @title AaveDistributionManagerV2
+ * @notice Accounting contract to manage multiple staking distributions
+ * @author Aave
+ **/
+contract AaveDistributionManagerV2 is AaveDistributionManager {
+  using SafeMath for uint256;
+
+  uint256 internal _distributionEnd;
+
+  event DistributionEndUpdate(uint256 ditributionEnd, uint256 distributionDuration);
+
+  constructor(address emissionManager) AaveDistributionManager(emissionManager, 0) {}
+
+  /**
+   * @dev Returns the timestamp of the end of the current distribution
+   * @return uint256 unix timestamp
+   **/
+  function getDistributionEnd() external view returns (uint256) {
+    return _getDistributionEnd();
+  }
+
+  /**
+   * @dev Extends the end of the distribution in regards of current timestamp.
+   * @param distributionDuration The unix timestamp duration of the new distribution
+   **/
+  function _extendDistribution(uint256 distributionDuration) internal {
+    _distributionEnd = block.timestamp.add(distributionDuration);
+    emit DistributionEndUpdate(_distributionEnd, distributionDuration);
+  }
+
+  /**
+   * @dev Returns the timestamp of the end of the current distribution
+   * @return uint256 unix timestamp
+   **/
+  function _getDistributionEnd() internal view override returns (uint256) {
+    return _distributionEnd;
+  }
+}

--- a/helpers/contracts-accessors.ts
+++ b/helpers/contracts-accessors.ts
@@ -3,7 +3,7 @@ import { eContractid, tEthereumAddress } from './types';
 import { MintableErc20 } from '../types/MintableErc20';
 import { StakedAave } from '../types/StakedAave';
 import { StakedAaveV2 } from '../types/StakedAaveV2';
-import {StakedAaveV3 } from '../types/StakedAaveV3';
+import { StakedAaveV3 } from '../types/StakedAaveV3';
 import { IcrpFactory } from '../types/IcrpFactory'; // Configurable right pool factory
 import { IConfigurableRightsPool } from '../types/IConfigurableRightsPool';
 import { IControllerAaveEcosystemReserve } from '../types/IControllerAaveEcosystemReserve';
@@ -198,7 +198,6 @@ export const deployStakedTokenV3 = async (
   return instance;
 };
 
-
 export const deployStakedAaveV3 = async (
   [
     stakedToken,
@@ -238,25 +237,16 @@ export const deployStakedAaveV3 = async (
 };
 
 export const deployAaveIncentivesController = async (
-  [rewardToken, rewardsVault, aavePsm, extraPsmReward, emissionManager, distributionDuration]: [
-    tEthereumAddress,
+  [rewardToken, aavePsm, extraPsmReward, emissionManager]: [
     tEthereumAddress,
     tEthereumAddress,
     string,
-    tEthereumAddress,
-    string
+    tEthereumAddress
   ],
   verify?: boolean
 ) => {
   const id = eContractid.AaveIncentivesController;
-  const args: string[] = [
-    rewardToken,
-    rewardsVault,
-    aavePsm,
-    extraPsmReward,
-    emissionManager,
-    distributionDuration,
-  ];
+  const args: string[] = [rewardToken, aavePsm, extraPsmReward, emissionManager];
   const instance = await deployContract<AaveIncentivesController>(id, args);
   await instance.deployTransaction.wait();
   if (verify) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13509,7 +13509,7 @@
               }
             },
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {

--- a/test/AaveIncentivesController/claim-rewards.spec.ts
+++ b/test/AaveIncentivesController/claim-rewards.spec.ts
@@ -82,7 +82,7 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
       await increaseTimeAndMine(100);
       const { aaveIncentivesController, stakedAave, aaveToken, aDaiMock } = testEnv;
 
-      const distributionEndTimestamp = await aaveIncentivesController.DISTRIBUTION_END();
+      const distributionEndTimestamp = await aaveIncentivesController.getDistributionEnd();
       const userAddress = await aaveIncentivesController.signer.getAddress();
 
       const underlyingAsset = aDaiMock.address;

--- a/test/AaveIncentivesController/configure-assets.spec.ts
+++ b/test/AaveIncentivesController/configure-assets.spec.ts
@@ -131,7 +131,7 @@ makeSuite('AaveIncentivesController configureAssets', (testEnv: TestEnv) => {
   for (const { assets, caseName, compareRules, customTimeMovement } of configureAssetScenarios) {
     it(caseName, async () => {
       const { aaveIncentivesController } = testEnv;
-      const distributionEndTimestamp = await aaveIncentivesController.DISTRIBUTION_END();
+      const distributionEndTimestamp = await aaveIncentivesController.getDistributionEnd();
 
       const assetConfigsUpdate: AssetUpdateData[] = [];
 

--- a/test/AaveIncentivesController/get-rewards-balance.spec.ts
+++ b/test/AaveIncentivesController/get-rewards-balance.spec.ts
@@ -35,7 +35,7 @@ makeSuite('AaveIncentivesController getRewardsBalance tests', (testEnv) => {
 
       const { aaveIncentivesController, users, aDaiMock } = testEnv;
 
-      const distributionEndTimestamp = await aaveIncentivesController.DISTRIBUTION_END();
+      const distributionEndTimestamp = await aaveIncentivesController.getDistributionEnd();
       const userAddress = users[1].address;
       const stakedByUser = 22 * caseName.length;
       const totalStaked = 33 * caseName.length;

--- a/test/AaveIncentivesController/handle-action.spec.ts
+++ b/test/AaveIncentivesController/handle-action.spec.ts
@@ -72,7 +72,7 @@ makeSuite('AaveIncentivesController handleAction tests', (testEnv) => {
         ]);
       }
 
-      const distributionEndTimestamp = await aaveIncentivesController.DISTRIBUTION_END();
+      const distributionEndTimestamp = await aaveIncentivesController.getDistributionEnd();
 
       const rewardsBalanceBefore = await aaveIncentivesController.getUserUnclaimedRewards(
         userAddress

--- a/test/AaveIncentivesController/initialize.spec.ts
+++ b/test/AaveIncentivesController/initialize.spec.ts
@@ -1,5 +1,5 @@
 import { makeSuite, TestEnv } from '../helpers/make-suite';
-import { MAX_UINT_AMOUNT } from '../../helpers/constants';
+import { MAX_UINT_AMOUNT, ZERO_ADDRESS } from '../../helpers/constants';
 
 const { expect } = require('chai');
 
@@ -7,7 +7,8 @@ makeSuite('AaveIncentivesController initialize', (testEnv: TestEnv) => {
   // TODO: useless or not?
   it('Tries to call initialize second time, should be reverted', async () => {
     const { aaveIncentivesController } = testEnv;
-    await expect(aaveIncentivesController.initialize()).to.be.reverted;
+    await expect(aaveIncentivesController.initialize(ZERO_ADDRESS, '0', ZERO_ADDRESS)).to.be
+      .reverted;
   });
   it('allowance on aave token should be granted to psm contract for pei', async () => {
     const { aaveIncentivesController, stakedAave, aaveToken } = testEnv;

--- a/test/helpers/deploy.ts
+++ b/test/helpers/deploy.ts
@@ -28,6 +28,7 @@ export const testDeployAaveStakeV1 = async (
 ) => {
   const proxyAdmin = await restWallets[0].getAddress();
   const emissionManager = await deployer.getAddress();
+  const distributionAdmin = await restWallets[1].getAddress();
 
   const stakedToken = aaveToken.address;
   const rewardsToken = aaveToken.address;
@@ -39,12 +40,12 @@ export const testDeployAaveStakeV1 = async (
 
   const aaveIncentivesControllerImplementation = await deployAaveIncentivesController([
     aaveToken.address,
-    vaultOfRewardsAddress,
     stakedAaveProxy.address,
     PSM_STAKER_PREMIUM,
     emissionManager,
-    (1000 * 60 * 60).toString(),
   ]);
+
+  const distribution = (1000 * 60 * 60).toString();
 
   const stakedAaveImpl = await deployStakedAave([
     stakedToken,
@@ -75,7 +76,8 @@ export const testDeployAaveStakeV1 = async (
   await insertContractAddressInDb(eContractid.StakedAave, stakedAaveProxy.address);
 
   const peiEncodedInitialize = aaveIncentivesControllerImplementation.interface.encodeFunctionData(
-    'initialize'
+    'initialize',
+    [vaultOfRewardsAddress, distribution, distributionAdmin]
   );
   await aaveIncentivesControllerProxy['initialize(address,address,bytes)'](
     aaveIncentivesControllerImplementation.address,


### PR DESCRIPTION
- Minimal changes to AaveDistributionManager V1 to reuse same logic at V2
  - Added _getDistributionEnd internal virtual getter to override at V2
  - The function `_getAssetIndex` now uses `_getDistributionEnd()` to abstract the access to `DISTRIBUTION_END`
- Add AaveDistributionManagerV2
   - Uses `_distributionEnd` internal variable instead of `DISTRIBUTION_END` inmmutable constant
  - Overrides `_getDistributionEnd()` getter to use `_distributionEnd` at `_getAssetIndex` function
   - Internal setter for extending the distribution end
- Add external distribution and reward vault setters at AaveIncentivesController managed by RoleManager
- Add new role REWARDS_ADMIN_ROLE for AaveIncentivesController to manage distribution and reward vault
- Fix tests and current scripts to use new AaveIncentivesController proxy initialization