### PR TITLE
Claim staked incentives + whitelisted on behalf claim

### DIFF
--- a/contracts/interfaces/IAaveIncentivesController.sol
+++ b/contracts/interfaces/IAaveIncentivesController.sol
@@ -17,7 +17,17 @@ interface IAaveIncentivesController {
   function claimRewards(
     address[] calldata assets,
     uint256 amount,
-    address to,
-    bool stake
+    address to
   ) external returns (uint256);
+
+  function claimRewardsOnBehalf(
+    address[] calldata assets,
+    uint256 amount,
+    address from,
+    address to
+  ) external returns (uint256);
+
+  function allowClaimOnBehalf(address user, address caller) external;
+
+  function getAllowedToClaimOnBehalf(address user) external view returns (address);
 }

--- a/contracts/stake/AaveIncentivesController.sol
+++ b/contracts/stake/AaveIncentivesController.sol
@@ -50,7 +50,7 @@ contract AaveIncentivesController is
   }
 
   function _onBehalfWhitelisted(address user, address caller) internal {
-    require(user != address(0) || caller != address(0), 'USER_OR_CALLER_NOT_ZERO_ADDRESS');
+    require(user != address(0) && caller != address(0), 'USER_OR_CALLER_NOT_ZERO_ADDRESS');
     require(_allowClaimOnBehalf[user] == caller, 'CALLER_NOT_ALLOWED_TO_CLAIM_ON_BEHALF');
   }
 
@@ -216,7 +216,7 @@ contract AaveIncentivesController is
 
     uint256 amountToClaim = amount > unclaimedRewards ? unclaimedRewards : amount;
     _usersUnclaimedRewards[user] = unclaimedRewards - amountToClaim; // Safe due to the previous line
-    amountToClaim = amountToClaim.add(amountToClaim.mul(EXTRA_PSM_REWARD).div(100));
+
     PSM.stake(to, amountToClaim);
     emit RewardsClaimed(user, to, amountToClaim);
 

--- a/helpers/contracts-accessors.ts
+++ b/helpers/contracts-accessors.ts
@@ -347,8 +347,13 @@ export const getStakedTokenV3 = async (address?: tEthereumAddress) => {
   );
 };
 
-export const getAaveIncentivesController = async (address: tEthereumAddress) =>
-  await getContract<AaveIncentivesController>(eContractid.AaveIncentivesController, address);
+export const getAaveIncentivesController = async (address?: tEthereumAddress) =>
+  await getContract<AaveIncentivesController>(
+    eContractid.AaveIncentivesController,
+    address ||
+      (await getDb().get(`${eContractid.AaveIncentivesController}.${DRE.network.name}`).value())
+        .address
+  );
 
 export const getIErc20Detailed = getContractFactory<Ierc20Detailed>(eContractid.IERC20Detailed);
 

--- a/test/AaveIncentivesController/claim-on-behalf.spec.ts
+++ b/test/AaveIncentivesController/claim-on-behalf.spec.ts
@@ -1,0 +1,98 @@
+import { makeSuite, SignerWithAddress, TestEnv } from '../helpers/make-suite';
+import { getRewards } from '../DistributionManager/data-helpers/base-math';
+import { getUserIndex } from '../DistributionManager/data-helpers/asset-user-data';
+import { getAssetsData } from '../DistributionManager/data-helpers/asset-data';
+import {
+  advanceBlock,
+  timeLatest,
+  waitForTx,
+  increaseTimeAndMine,
+  DRE,
+} from '../../helpers/misc-utils';
+import { getNormalizedDistribution } from '../helpers/ray-math';
+import { getBlockTimestamp } from '../../helpers/contracts-helpers';
+import { ZERO_ADDRESS } from '../../helpers/constants';
+import { Signer } from 'ethers/lib/ethers';
+import { solidity } from 'ethereum-waffle';
+import { parseEther } from '@ethersproject/units';
+
+const chai = require('chai');
+
+chai.use(solidity);
+
+const { expect } = chai;
+
+type ScenarioAction = {
+  caseName: string;
+  caller: number;
+  userOnBehalf: number | string;
+  revertReason?: string;
+  whitelisted?: boolean;
+};
+
+const getRewardsBalanceScenarios: ScenarioAction[] = [
+  {
+    caseName: 'User is ZERO ADDRESS',
+    caller: 2,
+    userOnBehalf: ZERO_ADDRESS,
+    revertReason: 'USER_OR_CALLER_NOT_ZERO_ADDRESS',
+  },
+  {
+    caseName: 'Claimer is NOT allowed to claim user rewards',
+    caller: 1,
+    userOnBehalf: 2,
+    revertReason: 'CALLER_NOT_ALLOWED_TO_CLAIM_ON_BEHALF',
+  },
+  {
+    caseName: 'Claimer is allowed to claim user rewards',
+    caller: 3,
+    userOnBehalf: 4,
+    whitelisted: true,
+  },
+];
+
+makeSuite('AaveIncentivesController - Claim on behalf', (testEnv: TestEnv) => {
+  for (const {
+    caseName,
+    caller: _caller,
+    userOnBehalf: _userOnBehalf,
+    whitelisted,
+    revertReason,
+  } of getRewardsBalanceScenarios) {
+    it(caseName, async () => {
+      await increaseTimeAndMine(100);
+
+      const { aaveIncentivesController, aDaiMock, rewardsAdmin, users } = testEnv;
+
+      const underlyingAsset = aDaiMock.address;
+      const totalStaked = 33 * caseName.length;
+      const emissionPerSecond = '1000';
+
+      await aaveIncentivesController.configureAssets([
+        { emissionPerSecond, underlyingAsset, totalStaked },
+      ]);
+
+      const caller = users[_caller];
+      const userOnBehalf =
+        _userOnBehalf === ZERO_ADDRESS ? ZERO_ADDRESS : users[_userOnBehalf].address;
+
+      if (whitelisted) {
+        await aaveIncentivesController
+          .connect(rewardsAdmin.signer)
+          .allowClaimOnBehalf(userOnBehalf, caller.address);
+      }
+
+      if (revertReason) {
+        await expect(
+          aaveIncentivesController
+            .connect(caller.signer)
+            .claimRewardsOnBehalf([underlyingAsset], '0', userOnBehalf, userOnBehalf)
+        ).to.be.revertedWith(revertReason);
+      } else {
+        await aaveIncentivesController
+          .connect(caller.signer)
+          .claimRewardsOnBehalf([underlyingAsset], '0', userOnBehalf, userOnBehalf);
+      }
+    });
+  }
+});

--- a/test/AaveIncentivesController/claim-rewards.spec.ts
+++ b/test/AaveIncentivesController/claim-rewards.spec.ts
@@ -211,9 +211,6 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
         );
       }
 
-      expectedClaimedAmount = expectedClaimedAmount.add(
-        expectedClaimedAmount.mul(PSM_STAKER_PREMIUM).div('100')
-      );
       expect(claimedAmount.toString()).to.be.equal(
         expectedClaimedAmount.toString(),
         'claimed amount are wrong'

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -22,7 +22,7 @@ const buildTestEnv = async (deployer: Signer, vaultOfRewards: Signer, restWallet
 
   const aaveToken = await deployMintableErc20(['Aave', 'aave', 18]);
 
-  await waitForTx(await aaveToken.connect(vaultOfRewards).mint(ethers.utils.parseEther('1000000')));
+  await waitForTx(await aaveToken.connect(vaultOfRewards).mint(ethers.utils.parseEther('2000000')));
   await topUpWalletsWithAave(
     [
       restWallets[0],
@@ -43,6 +43,12 @@ const buildTestEnv = async (deployer: Signer, vaultOfRewards: Signer, restWallet
     deployer,
     vaultOfRewards,
     restWallets
+  );
+
+  await waitForTx(
+    await aaveToken
+      .connect(vaultOfRewards)
+      .transfer(aaveIncentivesControllerProxy.address, ethers.utils.parseEther('1000000'))
   );
 
   await deployATokenMock(aaveIncentivesControllerProxy.address, 'aDai');

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -34,6 +34,7 @@ export interface TestEnv {
   stakedAaveV2: StakedAaveV2;
   rewardsVault: SignerWithAddress;
   deployer: SignerWithAddress;
+  rewardsAdmin: SignerWithAddress;
   users: SignerWithAddress[];
   aaveToken: MintableErc20;
   aaveIncentivesController: AaveIncentivesController;
@@ -51,6 +52,7 @@ const setBuidlerevmSnapshotId = (id: string) => {
 
 const testEnv: TestEnv = {
   deployer: {} as SignerWithAddress,
+  rewardsAdmin: {} as SignerWithAddress,
   users: [] as SignerWithAddress[],
   aaveToken: {} as MintableErc20,
   stakedAave: {} as StakedAave,
@@ -72,6 +74,11 @@ export async function initializeMakeSuite() {
     signer: _rewardsVault,
   };
 
+  const rewardsAdmin: SignerWithAddress = {
+    address: await restSigners[1].getAddress(),
+    signer: restSigners[1],
+  };
+
   for (const signer of restSigners) {
     testEnv.users.push({
       signer,
@@ -79,6 +86,7 @@ export async function initializeMakeSuite() {
     });
   }
   testEnv.deployer = deployer;
+  testEnv.rewardsAdmin = rewardsAdmin;
   testEnv.rewardsVault = rewardsVault;
   testEnv.stakedAave = await getStakedAave();
   testEnv.stakedAaveV2 = await getStakedAaveV2();


### PR DESCRIPTION
- Update method `claimRewards` logic to only be able to claim staked incentives
- New claim method `claimRewardsOnBehalf` to allow a 3rd user to claim rewards on behalf of user via whitelist, managed by Rewards role manager. This is suited for smart contracts where the incentives must be managed by external controllers or admins.
- Update test suite to new claim logic and coverage the new on behalf claim function